### PR TITLE
Added + symbol to regexpMail in utils.js to allow email addresses to contain the + symbol 

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -11,7 +11,7 @@ var crypto = require('crypto');
 var expressionCache = {};
 var sys = require('sys');
 
-var regexpMail = new RegExp('^[a-zA-Z0-9-_.]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$');
+var regexpMail = new RegExp('^[a-zA-Z0-9-_.+]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$');
 var regexpUrl = new RegExp('^(http[s]?:\\/\\/(www\\.)?|ftp:\\/\\/(www\\.)?|www\\.){1}([0-9A-Za-z-\\.@:%_\+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?');
 var ENCODING = 'utf8';
 var UNDEFINED = 'undefined';


### PR DESCRIPTION
Added + symbol to regexpMail in utils.js to allow email addresses to contain the + symbol which is part of the email standard and commonly used by Gmail and other email providers
