### PR TITLE
Fix init to handle correctly when socket path (string) is passed as port

### DIFF
--- a/index.js
+++ b/index.js
@@ -2769,7 +2769,7 @@ Framework.prototype.init = function(http, config, port, ip, options) {
 			self.isCoffee = true;
 	});
 
-	if (isNaN(port))
+	if (isNaN(port) && typeof(port) !== STRING)
 		port = null;
 
 	if (port !== null && typeof(port) === OBJECT) {
@@ -2882,7 +2882,13 @@ Framework.prototype.init = function(http, config, port, ip, options) {
 
 	if (!port) {
 		if (self.config['default-port'] === 'auto')
-			port = parseInt(process.env.PORT.toString());
+		{
+			var envPort = process.env.PORT.toString();
+			if(isNaN(envPort))
+				port = envPort;
+			else
+				port = parseInt(envPort);
+		}
 		else
 			port = self.config['default-port'];
 	}


### PR DESCRIPTION
server.listen has overload that takes socket path. The latest iisnode version uses it with a named pipe (i.e. \.\pipe{pipe-id}).

The empty visualstudio zip project needs to be changed to take the port correctly:
var port = process.env.PORT || 8000;   // instead of var port = parseInt(process.env.PORT || '8000');
