### PR TITLE
Fixed a bug to put correct exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -4005,7 +4005,7 @@ Framework.prototype.test = function(stop, names, cb) {
     if (!fs.existsSync(utils.combine(dir))) {
         if (cb) cb();
         if (stop) setTimeout(function() {
-            framework.stop(1);
+            framework.stop(framework.isTestError ? 1 : 0);
         }, 500);
         return self;
     }


### PR DESCRIPTION
when I use `stop` option on paramter of `framework.test()` function.
I got exit 1 code event there are any test error.
so I fixed to look `framework.isTestError` value.
