### PR TITLE
Check what test.data is existing

### DIFF
--- a/index.js
+++ b/index.js
@@ -4278,7 +4278,7 @@ Framework.prototype.testing = function(stop, callback) {
         self.testing(stop, callback);
     });
 
-    if (test.data.length > 0)
+    if (test.data && test.data.length > 0)
         req.end(test.data, ENCODING);
     else
         req.end();


### PR DESCRIPTION
I got an error when I ran `framework.assert('foo', function(next, name)`
so I added following error handling.

```
>> /foo/node_modules/total.js/index.js:3
>> key,beg,e);self.testsNO++;self.testing(stop,callback)});if(test.data.length>0)
>> ^
>> TypeError: Cannot read property 'length' of undefined
>>     at EventEmitter.Framework.testing (/foo/node_modules/total.js/index.js:3:6358)
>>     at EventEmitter.framework.testContinue (/foo/node_modules/total.js/index.js:3:4812)
>>     at process.on.framework.console (/foo/node_modules/total.js/index.js:6:10566)
>>     at process.EventEmitter.emit (events.js:95:17)
>>     at process._fatalException (node.js:272:26)
>> Exited with code: 7.
```
