### PR TITLE
Fix: duplicated cookie names.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13947,7 +13947,8 @@ http.ServerResponse.prototype.cookie = function(name, value, expires, options) {
 	if (self.headersSent || self.success)
 		return;
 
-	var builder = [name + '=' + encodeURIComponent(value)];
+	var cookieHeaderStart = name + '=';
+	var builder = [cookieHeaderStart + encodeURIComponent(value)];
 	var type = typeof(expires);
 
 	if (expires && !framework_utils.isDate(expires) && type === OBJECT) {
@@ -13979,6 +13980,12 @@ http.ServerResponse.prototype.cookie = function(name, value, expires, options) {
 		builder.push('HttpOnly');
 
 	var arr = self.getHeader('set-cookie') || [];
+
+	// Cookie, already, can be in array, resulting in duplicate 'set-cookie' header
+	var idx = arr.findIndex(cookieStr => cookieStr.startsWith(cookieHeaderStart));
+	if (idx !== -1)
+		arr.splice(idx, 1);
+
 	arr.push(builder.join('; '));
 	self.setHeader('Set-Cookie', arr);
 	return self;

--- a/test/controllers/default.js
+++ b/test/controllers/default.js
@@ -668,10 +668,12 @@ function pipe() {
 
 function view_cookie() {
     var self = this;
+    self.res.cookie('cookieR', 'O', new Date().add('d', 1));
     self.res.cookie('cookie1', '1', new Date().add('d', 1));
     self.res.cookie('cookie2', '2', new Date().add('d', 1));
     self.res.cookie('cookie3', '3', new Date().add('d', 1));
     self.res.cookie('cookie4', '4', new Date().add('d', 1));
+    self.res.cookie('cookieR', 'N', new Date().add('d', 1));
     self.plain('cookie');
 }
 

--- a/test/test-framework-debug.js
+++ b/test/test-framework-debug.js
@@ -580,6 +580,7 @@ function test_routing(next) {
 
 			var cookie = headers['set-cookie'].join('');
 			assert(cookie.indexOf('cookie1=1;') !== -1 && cookie.indexOf('cookie2=2;') !== -1 && cookie.indexOf('cookie3=3;') !== -1, 'Cookie problem.');
+			assert(cookie.indexOf('cookieR=O;') === -1 && cookie.indexOf('cookieR=N;') !== -1 && cookie.indexOf('cookieR=') === cookie.lastIndexOf('cookieR='), 'Two cookies with same name');
 			complete();
 		});
 	});


### PR DESCRIPTION
Hi,

If cookie method is invoked more than once with same cookie name
than the new 'Set-Cookie' header with same cookie name is added
to response. As an outcome the old value(s) of cookie and new one
are transmitted to client.
