### PR TITLE
Update utils.js join method

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1617,7 +1617,7 @@ exports.path = function(path, delimiter) {
 };
 
 exports.join = function() {
-	var path = isWindows ? [] : [''];
+	var path = [''];
 
 	for (var i = 0; i < arguments.length; i++) {
 		var current = arguments[i];
@@ -1631,7 +1631,8 @@ exports.join = function() {
 		path.push(current);
 	}
 
-	return path.join('/');
+	var path = path.join('/');
+	return !isWindows ? path : path.indexOf(':') > -1 ? path.substring(1) : path;
 };
 
 /**


### PR DESCRIPTION
The [previous fix](https://github.com/totaljs/framework/commit/8bccf71b1bacd3b99dccb58004a23523bb47b99d) unfortunatelly created another issue in windows.
Now it will remove initial `/` only if path contains `:` so only if path looks like this `/C:/whatever` 