### PR TITLE
Fix F.modify usage error in version 2.4.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -2759,7 +2759,7 @@ Framework.prototype.modify = function(fn) {
 	if (!F.modificators)
 		F.modificators = [];
 	F.modificators.push(fn);
-	fn.$owner = owner;
+	fn.$owner = _owner;
 	return F;
 };
 


### PR DESCRIPTION
This fixes the error triggered when F.modify is used after upgrading to version 2.4.0

```
2017-03-02 18:25:23: F.install('definition') ---> ReferenceError: owner is not defined ReferenceError: owner is not defined
    at WebSocket.Framework.web.Framework.route.Framework.merge.Framework.modify (C:\xxx\node_modules\total.js\index.js:2762:14)
    at Object.<anonymous> (C:\xxx\definitions\modifier.js:4:3)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at WebSocket.Framework.web.Framework.route.Framework.merge.Framework.$load.F.temporary.internal.resources.arr.forEach.arr.forEach.arr.forEach.arr.forEach.Framework.install.uptodateName [as install] (C:\xxx\node_modules\total.js\index.js:3358:11)
    at C:\xxx\node_modules\total.js\index.js:2911:27
```