### PR TITLE
fix js effective path

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,15 +3,15 @@
 # Top-most EditorConfig file
 root = true
 
-[src/**/**.js]
+[*.js]
 indent_style = tab
 indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = true
+insert_final_newline = false
 max_line_length = 120
 
-[**.json]
+[*.json]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Fix my mistake. The effective path is all js files, not only the path of src.

All js files have no final new line, so I set the value of insert_final_newline to false.