### PR TITLE
add problem string in res.$throw

### DIFF
--- a/index.js
+++ b/index.js
@@ -14953,7 +14953,7 @@ function extend_response(PROTO) {
 		if (req.method === 'HEAD')
 			res.end();
 		else
-			res.end(res.options.body || U.httpStatus(res.options.code));
+			res.end(res.options.body || U.httpStatus(res.options.code) + prepare_error(res.options && res.options.problem));
 
 		var key = 'error' + res.options.code;
 		F.$events[key] && F.emit(key, req, res, res.options.problem);


### PR DESCRIPTION
Add problem string in res.$throw base on #555 .
I found we only send the problem message by controller.throw. 
Please consider to add problem message also in res.throw.