### PR TITLE
Improved /dependencies file require() logic for relative/absolute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -3470,6 +3470,8 @@ F.install = function(type, name, declaration, options, callback, internal, useRe
 			if (declaration[0] === '~')
 				declaration = declaration.substring(1);
 			if (type !== 'config' && type !== 'resource' && type !== 'package' && type !== 'component' && !REG_SCRIPTCONTENT.test(declaration)) {
+				var relative = F.path.root(declaration);
+				if (existsSync(relative)) declaration = relative;
 				if (!existsSync(declaration))
 					throw new Error('The ' + type + ': ' + declaration + ' doesn\'t exist.');
 				useRequired = true;
@@ -3790,6 +3792,8 @@ F.install = function(type, name, declaration, options, callback, internal, useRe
 		try {
 
 			if (useRequired) {
+				var relative = F.path.root(declaration);
+				if (existsSync(relative)) declaration = relative;
 				delete require.cache[require.resolve(declaration)];
 				obj = require(declaration);
 
@@ -3838,6 +3842,8 @@ F.install = function(type, name, declaration, options, callback, internal, useRe
 			}
 
 			if (useRequired) {
+				var relative = F.path.root(declaration);
+				if (existsSync(relative)) declaration = relative;
 				delete require.cache[require.resolve(declaration)];
 				obj = require(declaration);
 				content = Fs.readFileSync(declaration).toString(ENCODING);
@@ -3900,6 +3906,8 @@ F.install = function(type, name, declaration, options, callback, internal, useRe
 		try {
 
 			if (useRequired) {
+				var relative = F.path.root(declaration);
+				if (existsSync(relative)) declaration = relative;
 				obj = require(declaration);
 				(function(name) {
 					setTimeout(() => delete require.cache[name], 1000);
@@ -4001,6 +4009,8 @@ F.install = function(type, name, declaration, options, callback, internal, useRe
 
 		try {
 			if (useRequired) {
+				var relative = F.path.root(declaration);
+				if (existsSync(relative)) declaration = relative;
 				obj = require(declaration);
 				(function(name) {
 					setTimeout(function() {


### PR DESCRIPTION
Current `/dependencies` file logic doesn't allow to use paths relative to [root of Total.js project](https://docs.totaljs.com/latest/en.html#api~FrameworkPath~F.path.root), only absolute like this:
```javascript
module  (1 minute) : ~/Volumes/Development/modules/Miscellaneous/clienterror.js
```
If resolution fails, Total.js [throws Error](https://github.com/totaljs/framework/blob/v2.9.2/index.js#L3473-L3474).

This commit changes behavior of resolving & requiring deps, so everyone may use both absolute & relative paths for deps:

Absolute (wherever the file is located):
```javascript
module  (1 minute) : ~/Volumes/Development/modules/Miscellaneous/clienterror.js 
```
Relative to [project root](https://docs.totaljs.com/latest/en.html#api~FrameworkPath~F.path.root)
```javascript
module  (1 minute) : ~/plugins/clienterror.js
// or
module  (1 minute) : ~./plugins/clienterror.js
```

The behavior similar to Node.js core modules resolving - first it tries to locate file locally relative to project root, then it tries to locate it via absolute path.

So, now you can use your `/dependencies` wherever they are located in (absolutely static or relatively path)