### PR TITLE
Make U.isArray() more reliable (multi-frame context)

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -2053,7 +2053,7 @@ exports.parseFloat = function(obj, def) {
  * @return {Boolean}
  */
 exports.isArray = function(obj) {
-	return obj instanceof Array;
+	return Object.prototype.toString.call(input) === '[object Array]';
 };
 
 /**


### PR DESCRIPTION
The problems with using `instanceof Array` arises when it comes to scripting in multi-frame DOM environments. In a nutshell, Array objects created within one iframe do not share [[Prototype]]’s with arrays created within another iframe. Their constructors are different objects and so both `instanceof` and `constructor` checks fail. The proposed solution is not dependent on frames (since it checks internal [[Class]]) and is more robust than duck-typing approach (e.g. checking for Prototype methods like `.slice()` that are unique to the Prototye). 

Great writeup here: http://perfectionkills.com/instanceof-considered-harmful-or-how-to-write-a-robust-isarray/

PS: not sure which branch to target, can change if v3.0.1 is the wrong one!