### PR TITLE
Fix workers crash when debugging main process with --inspect or --debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -868,6 +868,16 @@ function Framework() {
 	self.isLE = Os.endianness ? Os.endianness() === 'LE' : true;
 	self.isHTTPS = false;
 
+	// Fix for workers crash (port in use) when debugging main process with --inspect or --debug
+	// See: https://github.com/nodejs/node/issues/14325 and https://github.com/nodejs/node/issues/9435
+	process.execArgv.forEach((val, i, arr) => {
+		if (val.indexOf('inspect') != -1 || val.indexOf('debug') != -1) {
+			// Setting inspect/debug port to random unused
+			arr[i] = '--inspect=0';
+		}
+	});
+	HEADERS.workers.execArgv = process.execArgv;
+
 	// It's hidden
 	// self.waits = {};
 


### PR DESCRIPTION
**This commit fixes problem:**
When main Node.js process started with `--inspect` or `--debug`, Total.js worker (`child_process`) will be started with the same Node.js executable arguments as main process (default behavior of  [child_process.fork(modulePath[, args][, options])](https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_child_process_fork_modulepath_args_options)) which causes interference between main process debugging port and child process debugging port, that's why worker process exiting with code `12`

_P.S.>_ If Node.js started with huge amount of executable arguments, this patch may have impact on Total.js app's startup time