### PR TITLE
Fix broken link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Node.js framework
 
 __Total.js framework__ is a framework for Node.js platfrom written in `pure` JavaScript similar to PHP's Laravel or Python's Django or ASP.NET MVC. It can be used as web, desktop, service or IoT application.
 
-__IMPORTANT__: [New version __Total.js 4__](github.com/totaljs/framework4)
+__IMPORTANT__: [New version __Total.js 4__](https://github.com/totaljs/framework4)
 
 ```bash
 $ npm install -g total.js


### PR DESCRIPTION
The link to Total.js framework v4 was correct,
except that it was lacking "https://" at the start,
which means the link may not work depending on the system.
So, this commit adds "https://" at the start.